### PR TITLE
Allow multiple switches and persist accessories on restart

### DIFF
--- a/.homebridge/config.json
+++ b/.homebridge/config.json
@@ -15,7 +15,8 @@
 					"name": "Example Switch",
 					"manufacturer": "Example Manufacturer",
 					"model": "Example Model",
-					"serialNumber": "693-29-284"
+					"serialNumber": "693-29-284",
+					"accessoryId": 0
 				}
 			]
 		}

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ In your **_`config.json`_** -file, the following information needs to be added i
           "name": "Switch",
           "manufacturer": "Nexa",
           "model": "PER-1500",
-          "serialNumber": "481-48-592"
+          "serialNumber": "481-48-592",
+          "accessoryId": 0
         }
       ]
     },

--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ NexaSwitchPlatform.prototype.addAccessory = function(accessoryInformation) {
 NexaSwitchPlatform.prototype.configureAccessory = function(accessory) {
     this.log(`Restoring accessory '${accessory.context.name} (${accessory.context.manufacturer} ${accessory.context.model})'...`);
     
-    const switchService = accessory.addService(Service.Switch, accessory.context.name);
+    const switchService = accessory.getService(Service.Switch);
     switchService.getCharacteristic(Characteristic.On)
         .on("set", this.setSwitchOnCharacteristic.bind({ emitterId: this.config.emitterId,
                                                          accessoryIndex: accessory.context.accessoryId }));

--- a/index.js
+++ b/index.js
@@ -124,9 +124,9 @@ NexaSwitchPlatform.prototype.validateConfig = function(config) {
 };
 
 NexaSwitchPlatform.prototype.accessoryRegistered = function(uuid) {
-    for (let index in this.accessories) {
-        if (this.accessories[index].UUID === uuid) {
-            this.accessoriesToBeUnregistered.splice(index);
+    for (let index in this.accessoriesToBeUnregistered) {
+        if (this.accessoriesToBeUnregistered[index].UUID === uuid) {
+            this.accessoriesToBeUnregistered.splice(index, 1);
             return true;
         }
     }

--- a/index.js
+++ b/index.js
@@ -89,13 +89,19 @@ NexaSwitchPlatform.prototype.addAccessory = function(accessoryInformation) {
     const switchService = accessory.addService(Service.Switch, accessoryInformation.name);
     switchService.getCharacteristic(Characteristic.On)
         .on("set", this.setSwitchOnCharacteristic.bind({ emitterId: this.config.emitterId,
-                                                         accessoryIndex: this.config.accessoryInformation.accessoryId }));
+                                                         accessoryIndex: accessoryInformation.accessoryId }));
 
     this.accessoriesToBeRegistered.push(accessory);
 };
 
 NexaSwitchPlatform.prototype.configureAccessory = function(accessory) {
     this.log(`Restoring accessory '${accessory.context.name} (${accessory.context.manufacturer} ${accessory.context.model})'...`);
+    
+    const switchService = accessory.addService(Service.Switch, accessory.context.name);
+    switchService.getCharacteristic(Characteristic.On)
+        .on("set", this.setSwitchOnCharacteristic.bind({ emitterId: this.config.emitterId,
+                                                         accessoryIndex: accessory.context.accessoryId }));
+    
     this.accessories.push(accessory);
 };
 

--- a/index.js
+++ b/index.js
@@ -88,7 +88,8 @@ NexaSwitchPlatform.prototype.addAccessory = function(accessoryInformation) {
 
     const switchService = accessory.addService(Service.Switch, accessoryInformation.name);
     switchService.getCharacteristic(Characteristic.On)
-        .on("set", this.setSwitchOnCharacteristic.bind({ emitterId: this.config.emitterId, accessoryIndex: (this.config.accessoryInformation.indexOf(accessoryInformation) + 1) }));
+        .on("set", this.setSwitchOnCharacteristic.bind({ emitterId: this.config.emitterId,
+                                                         accessoryIndex: this.config.accessoryInformation.accessoryId }));
 
     this.accessoriesToBeRegistered.push(accessory);
 };

--- a/index.js
+++ b/index.js
@@ -80,6 +80,7 @@ NexaSwitchPlatform.prototype.addAccessory = function(accessoryInformation) {
     accessory.context.name = accessoryInformation.name;
     accessory.context.manufacturer = accessoryInformation.manufacturer;
     accessory.context.model = accessoryInformation.model;
+    accessory.context.accessoryId = accessoryInformation.accessoryId;
 
     accessory.getService(Service.AccessoryInformation)
         .setCharacteristic(Characteristic.Manufacturer, accessoryInformation.manufacturer)


### PR DESCRIPTION
Homebridge would crash on reboot when multiple accessories were defined under the NexaSwitchPlatform.
- The splice operation would remove not only the entry we want to remove, but all that have a higher index as well.
- Can not loop over a vector and use that index to edit a different (and possibly already edited) vector by the same index.